### PR TITLE
Graft fix hmac

### DIFF
--- a/etna.gemspec
+++ b/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1'
+  spec.version           = '0.1.1'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/lib/etna/auth.rb
+++ b/lib/etna/auth.rb
@@ -17,7 +17,7 @@ module Etna
       # a valid token. Both of these will
       # not validate individual permissions;
       # this is up to the controller
-      return fail_or_redirect unless create_user || approve_hmac
+      return fail_or_redirect unless approve_hmac || create_user
 
       @app.call(env)
     end

--- a/lib/etna/controller.rb
+++ b/lib/etna/controller.rb
@@ -34,10 +34,7 @@ module Etna
     alias_method :require_param, :require_params
 
     def route_path(name, params={})
-      route = @server.class.routes.find do |route|
-        route.name.to_s == name.to_s
-      end
-      return route ? route.path(params) : nil
+      @server.class.route_path(@request, name, params)
     end
 
     def route_url(name, params={})

--- a/lib/etna/controller.rb
+++ b/lib/etna/controller.rb
@@ -37,8 +37,13 @@ module Etna
       route = @server.class.routes.find do |route|
         route.name.to_s == name.to_s
       end
-      return nil if route.nil?
-      @request.scheme + '://' + @request.host + route.path(params)
+      return route ? route.path(params) : nil
+    end
+
+    def route_url(name, params={})
+      path = route_path(name,params)
+      return nil unless path
+      @request.scheme + '://' + @request.host + path
     end
 
     # methods for returning a view

--- a/lib/etna/route.rb
+++ b/lib/etna/route.rb
@@ -16,9 +16,11 @@ module Etna
     end
 
     def path(params)
-      @route
-        .gsub(/:([\w]+)/) { params[$1.to_sym] }
-        .gsub(/\*([\w]+)$/) { params[$1.to_sym] }
+      URI.escape(
+        @route
+          .gsub(/:([\w]+)/) { params[$1.to_sym] }
+          .gsub(/\*([\w]+)$/) { params[$1.to_sym] }
+      )
     end
 
     def call(app, request)

--- a/lib/etna/route.rb
+++ b/lib/etna/route.rb
@@ -16,11 +16,9 @@ module Etna
     end
 
     def path(params)
-      URI.escape(
-        @route
-          .gsub(/:([\w]+)/) { params[$1.to_sym] }
-          .gsub(/\*([\w]+)$/) { params[$1.to_sym] }
-      )
+      @route
+        .gsub(/:([\w]+)/) { URI.encode_www_form_component( params[$1.to_sym]) }
+        .gsub(/\*([\w]+)$/) { URI.encode_www_form_component( params[$1.to_sym]) }
     end
 
     def call(app, request)

--- a/lib/etna/route.rb
+++ b/lib/etna/route.rb
@@ -15,11 +15,32 @@ module Etna
       @method == request.request_method && request.path.match(route_regexp)
     end
 
+    NAMED_PARAM=/:([\w]+)/
+    GLOB_PARAM=/\*([\w]+)$/
+
+    PARAM_TYPES=[ NAMED_PARAM, GLOB_PARAM ]
+
     UNSAFE=/[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,]/
-    def path(params)
-      @route
-        .gsub(/:([\w]+)/) { URI.encode( params[$1.to_sym], UNSAFE) }
-        .gsub(/\*([\w]+)$/) { URI.encode( params[$1.to_sym], UNSAFE) }
+
+    def path(params=nil)
+      if params
+        PARAM_TYPES.reduce(@route) do |route,pat|
+          route.gsub(pat) do
+           URI.encode( params[$1.to_sym], UNSAFE)
+          end
+        end
+      else
+        @route
+      end
+    end
+
+    def parts
+      part_list = PARAM_TYPES.map do |pat|
+        "(?:#{pat.source})"
+      end
+      @route.scan(
+        /(?:#{part_list.join('|')})/
+      ).flatten.compact
     end
 
     def call(app, request)
@@ -104,9 +125,9 @@ module Etna
           '\A' +
           @route.
             # any :params match separator-free strings
-            gsub(/:([\w]+)/, '(?<\1>[^\.\/\?]+)').
+            gsub(NAMED_PARAM, '(?<\1>[^\.\/\?]+)').
             # any *params match arbitrary strings
-            gsub(/\*([\w]+)$/, '(?<\1>.+)').
+            gsub(GLOB_PARAM, '(?<\1>.+)').
             # ignore any trailing slashes in the route
             gsub(/\/\z/, '') +
           # trailing slashes in the path can be ignored

--- a/lib/etna/route.rb
+++ b/lib/etna/route.rb
@@ -15,10 +15,11 @@ module Etna
       @method == request.request_method && request.path.match(route_regexp)
     end
 
+    UNSAFE=/[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,]/
     def path(params)
       @route
-        .gsub(/:([\w]+)/) { URI.encode_www_form_component( params[$1.to_sym]) }
-        .gsub(/\*([\w]+)$/) { URI.encode_www_form_component( params[$1.to_sym]) }
+        .gsub(/:([\w]+)/) { URI.encode( params[$1.to_sym], UNSAFE) }
+        .gsub(/\*([\w]+)$/) { URI.encode( params[$1.to_sym], UNSAFE) }
     end
 
     def call(app, request)

--- a/lib/etna/server.rb
+++ b/lib/etna/server.rb
@@ -8,15 +8,21 @@ module Etna
         @routes << Etna::Route.new(
           method,
           path,
-          options,
+          (@default_options || {}).merge(options),
           &block
         )
+      end
+
+      def using(options={}, &block)
+        @default_options = options
+        instance_eval(&block)
+        @default_options = nil
       end
 
       def get(path, options={}, &block)
         route('GET', path, options, &block)
       end
-      
+
       def post(path, options={}, &block)
         route('POST', path, options, &block)
       end

--- a/lib/etna/server.rb
+++ b/lib/etna/server.rb
@@ -29,6 +29,13 @@ module Etna
         route('DELETE', path, options, &block)
       end
 
+      def route_path(request,name,params={})
+        route = routes.find do |route|
+          route.name.to_s == name.to_s
+        end
+        return route ? route.path(params) : nil
+      end
+
       attr_reader :routes
     end
 

--- a/lib/etna/server.rb
+++ b/lib/etna/server.rb
@@ -13,7 +13,7 @@ module Etna
         )
       end
 
-      def using(options={}, &block)
+      def with(options={}, &block)
         @default_options = options
         instance_eval(&block)
         @default_options = nil

--- a/lib/etna/sign_service.rb
+++ b/lib/etna/sign_service.rb
@@ -1,5 +1,6 @@
 # General signing/hashing utilities.
 require 'jwt'
+require 'securerandom'
 
 module Etna
   class SignService
@@ -28,6 +29,10 @@ module Etna
         private_key,
         @application.config(:token_algo)
       )
+    end
+
+    def uid(size=nil)
+      SecureRandom.hex(size)
     end
 
     def jwt_decode(token)

--- a/lib/etna/test_auth.rb
+++ b/lib/etna/test_auth.rb
@@ -59,7 +59,7 @@ module Etna
 
       return failure(401, 'Authorization header missing') if auth(:missing)
 
-      return failure(401, 'Authorization header malformed') unless user_auth || hmac_auth
+      return failure(401, 'Authorization header malformed') unless hmac_auth || user_auth
       @app.call(env)
     end
   end

--- a/lib/etna/test_auth.rb
+++ b/lib/etna/test_auth.rb
@@ -7,7 +7,7 @@ module Etna
   class TestAuth
     def self.token_header(params)
       token = Base64.strict_encode64(params.to_json)
-      return [ 'Authorization', "Basic #{token}" ]
+      return [ 'Authorization', "Etna #{token}" ]
     end
 
     def self.hmac_header(params)
@@ -32,7 +32,7 @@ module Etna
     end
 
     def user_auth
-      token = auth(:basic)
+      token = auth(:etna)
 
       return false unless token
 

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -124,7 +124,7 @@ describe Etna::Route do
 
   it 'looks up route names' do
     Arachne::Server.get('/silk/:query', as: :silk) do
-      [ 200, {}, [ route_path(:silk, @params) ] ]
+      [ 200, {}, [ route_url(:silk, @params) ] ]
     end
     @app = setup_app(Arachne::Server.new(test: {}))
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -32,6 +32,18 @@ describe Etna::Server do
     expect(last_response.body).to eq('ok')
   end
 
+  it 'should allow route definitions with #with' do
+    Arachne::Server.with(action: 'web#silk') do
+      get '/silk'
+    end
+    @app = setup_app(Arachne::Server.new(test: {}))
+
+    get '/silk'
+
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq('ok')
+  end
+
   it 'should allow route definitions with actions' do
     Arachne::Server.route('GET', '/silk', action: 'web#silk')
     @app = setup_app(Arachne::Server.new(test: {}))

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,4 +1,4 @@
-describe Etna::Route do
+describe Etna::Server do
   include Rack::Test::Methods
 
   attr_reader :app

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -65,6 +65,18 @@ describe Etna::User do
       expect(@editor.can_see_restricted?(:labors)).to be_truthy
       expect(@viewer.can_see_restricted?(:labors)).to be_falsy
     end
+    it 'gives a list of user projects' do
+      expect(@overlord.projects).to eq(['administration'])
+      expect(@admin.projects).to eq(['labors'])
+      expect(@editor.projects).to eq(['labors'])
+      expect(@viewer.projects).to eq(['labors'])
+    end
+    it 'gives a list of user permissions' do
+      expect(@overlord.permissions).to eq( 'administration' => { role: :admin, restricted: false } )
+      expect(@admin.permissions).to eq( 'labors' => { role: :admin, restricted: true } )
+      expect(@editor.permissions).to eq( 'labors' => { role: :editor, restricted: true } )
+      expect(@viewer.permissions).to eq( 'labors' => { role: :viewer, restricted: false } )
+    end
   end
 
   it "gives global permission to an administrator" do


### PR DESCRIPTION
There are a bunch of etna bug-fixes in here that I collected while working on metis. Notably:

1) The hmac auth should come before the user_auth check, otherwise if you have a token and request an hmac-signed url the token will get you past Etna::Auth, while the endpoint will expect you to have cleared via hmac.

2) ParseBody used to only check one type of input - now it parses the body into params based on content-type, but always also parses URL params

3) TestAuth should use the "Etna <token>" for checking the token rather than "Basic <token>"

4) The Route previously generated a route_path which was actually a full URL - now there is a route_url and route_path - also route params are substituted more better when forming a url

5) The sign service supports generating a random uid.