### PR TITLE
Graft add error logging

### DIFF
--- a/etna.gemspec
+++ b/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.3'
+  spec.version           = '0.1.4'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/lib/etna.rb
+++ b/lib/etna.rb
@@ -1,4 +1,5 @@
 require_relative './etna/ext'
+require_relative './etna/logger'
 require_relative './etna/server'
 require_relative './etna/command'
 require_relative './etna/errors'

--- a/lib/etna/logger.rb
+++ b/lib/etna/logger.rb
@@ -1,0 +1,21 @@
+module Etna
+  class Logger < ::Logger
+    def initialize(log_dev, age, size)
+      super
+
+      self.formatter = proc do |severity, datetime, progname, msg|
+        format(severity, datetime, progname, msg)
+      end
+    end
+
+    def format(severity, datetime, progname, msg)
+      "#{severity} #{datetime.iso8601} #{@request.env['etna.request_id']} #{msg}\n"
+    end
+
+    def request=(request)
+      @request = request
+      @request.env['etna.logger'] = self
+      @request.env['etna.request_id'] = (rand*36**6).to_i.to_s(36)
+    end
+  end
+end

--- a/lib/etna/server.rb
+++ b/lib/etna/server.rb
@@ -49,7 +49,8 @@ module Etna
       @request = Rack::Request.new(env)
 
       @request.env['etna.server'] = self
-      @request.env['etna.logger'] = @logger
+
+      @logger.request = @request
 
       route = self.class.routes.find do |route|
         route.matches? @request
@@ -81,7 +82,7 @@ module Etna
     end
 
     def setup_logger
-      @logger = Logger.new(
+      @logger = Etna::Logger.new(
         # The name of the log_file, required.
         application.config(:log_file),
         # Number of old copies of the log to keep.

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -32,4 +32,72 @@ describe Etna::Controller do
     get('/test?project_name=labors')
     expect(last_response.status).to eq(200)
   end
+
+  context '#logging' do
+    before(:each) do
+      @log_file = 'error.log'
+      Timecop.freeze('2000-01-01')
+      # fixes the request_id, which otherwise is random
+      Etna::Logger.define_method(:rand) do
+        0.23456
+      end
+    end
+    after(:each) do
+      ::File.unlink(@log_file)
+      Timecop.return
+      Etna::Logger.remove_method(:rand)
+    end
+
+    it 'reports etna errors in the log file' do
+      Arachne::Server.get('/test') { raise Etna::Forbidden, 'You cannot do that.' }
+
+      @app = setup_app(
+        Arachne::Server.new(test: { log_file: @log_file }),
+        [ Etna::TestAuth ]
+      )
+
+      header(*Etna::TestAuth.token_header(
+        email: 'janus@two-faces.org',
+        perm: 'e:labors'
+      ))
+
+      get('/test')
+      expect(last_response.status).to eq(403)
+
+      output = <<EOT
+# Logfile created on 2000-01-01 00:00:00 +0000 by logger.rb/61378
+ERROR 2000-01-01T00:00:00+00:00 8fzmq8 Exiting with 403, You cannot do that.
+EOT
+      expect(File.read(@log_file)).to eq(output)
+    end
+
+    it 'reports unspecified errors in the log file' do
+      Arachne::Server.get('/test') { raise 'Something broke.' }
+
+      @app = setup_app(
+        Arachne::Server.new(test: { log_file: @log_file }),
+        [ Etna::TestAuth ]
+      )
+
+      header(*Etna::TestAuth.token_header(
+        email: 'janus@two-faces.org',
+        perm: 'e:labors'
+      ))
+
+      get('/test')
+      expect(last_response.status).to eq(500)
+      output = <<EOT
+# Logfile created on 2000-01-01 00:00:00 +0000 by logger.rb/61378
+ERROR 2000-01-01T00:00:00+00:00 8fzmq8 Caught unspecified error
+ERROR 2000-01-01T00:00:00+00:00 8fzmq8 Something broke.
+EOT
+      # it reports the error
+      log_contents = File.foreach(@log_file).to_a
+      expect(log_contents[0..2].join).to eq(output)
+
+      # it reports backtraces
+      BACKTRACE = %r!(/[^/]+)+:[0-9]+:in `.*'!
+      expect(log_contents[3..-1]).to all( match(BACKTRACE) )
+    end
+  end
 end


### PR DESCRIPTION
This PR updates the way etna applications log errors. Specifically it:
- Creates a unique request_id to identify log lines by request
- Defines a new log line format, where each log line includes severity, date/time, request_id and log message
- Rescues untrapped errors and logs them along with a backtrace
- Fixes the Etna::Controller#log function