### PR TITLE
Graft fix json routes

### DIFF
--- a/etna.gemspec
+++ b/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.6'
+  spec.version           = '0.1.7'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/lib/etna/controller.rb
+++ b/lib/etna/controller.rb
@@ -82,6 +82,7 @@ module Etna
     end
 
     def failure(status, msg)
+      @response['Content-Type'] = 'application/json'
       @response.status = status
       @response.write(msg.to_json)
       @response.finish

--- a/lib/etna/route.rb
+++ b/lib/etna/route.rb
@@ -47,7 +47,7 @@ module Etna
       update_params(request)
 
       unless authorized?(request)
-        return [ 403, {}, ['You are forbidden from performing this action.'] ]
+        return [ 403, { 'Content-Type' => 'application/json' }, [ { error: 'You are forbidden from performing this action.' }.to_json ] ]
       end
 
       if @action

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -109,6 +109,21 @@ describe Etna::Server do
     expect(last_response.body).to eq('25-octagon')
   end
 
+  it 'enforces route parameters over other parameters' do
+    Arachne::Server.post('/silk/:thread_weight/:shape') do
+      [ 200, {}, [ "#{@params[:thread_weight]}-#{@params[:shape]}" ] ]
+    end
+    @app = setup_app(Arachne::Server)
+
+    post('/silk/25/octagon', { thread_weight: 35, shape: 'dodecagon' }.to_json, 'CONTENT_TYPE' => 'application/json')
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq('25-octagon')
+
+    post('/silk/25/octagon?thread_weight=35&shape=dodecagon')
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq('25-octagon')
+  end
+
   it 'allows route globbing with slashes' do
     description = 'A tapestry/weave of the Olympians.'
     Arachne::Server.get('/silk/*description') do


### PR DESCRIPTION
Fixes lack of json headers in error responses (for easier type checking) and uses json response for route auth errors.