### PR TITLE
Issue38 expose client route path

### DIFF
--- a/etna.gemspec
+++ b/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.9'
+  spec.version           = '0.1.10'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/lib/etna/client.rb
+++ b/lib/etna/client.rb
@@ -15,16 +15,16 @@ module Etna
 
     attr_reader :routes
 
+    def route_path(route, params)
+      Etna::Route.path(route[:route], params)
+    end
+
     private
 
     def set_routes
       response = options('/')
       status_check!(response)
       @routes = JSON.parse(response.body, symbolize_names: true)
-    end
-
-    def route_path(route, params)
-      Etna::Route.path(route[:route], params)
     end
 
     def define_route_helpers

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -54,4 +54,10 @@ describe Etna::Client do
 
     expect{client.weave}.to raise_error(ArgumentError, 'Missing required param fabric')
   end
+
+  it 'allows users to construct an individual route' do
+    client = Etna::Client.new('https://arachne.test', 'token')
+    weave = client.routes.find { |e| e[:name] == 'weave' }
+    expect(client.route_path(weave, {fabric: 'silk'})).to eq '/weave/silk'
+  end
 end


### PR DESCRIPTION
#38 

Note that this change is on top of your `graft-repair-hmac` branch, so not on top of master.

Exposes the `route_path` method on `Etna::Client` as public, so it can be used by other applications to generate route paths.