### PR TITLE
Issue39 auth save token

### DIFF
--- a/etna.gemspec
+++ b/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.9'
+  spec.version           = '0.1.10'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/lib/etna/auth.rb
+++ b/lib/etna/auth.rb
@@ -77,8 +77,7 @@ module Etna
 
       begin
         payload, header = application.sign.jwt_decode(token)
-        payload['token'] = token
-        return request.env['etna.user'] = Etna::User.new(payload.map{|k,v| [k.to_sym, v]}.to_h)
+        return request.env['etna.user'] = Etna::User.new(payload.map{|k,v| [k.to_sym, v]}.to_h, token)
       rescue
         # bail out if anything goes wrong
         return false

--- a/lib/etna/auth.rb
+++ b/lib/etna/auth.rb
@@ -50,7 +50,7 @@ module Etna
       #
       # We prefer the param so we can use the header elsewhere
 
-      params(request)[Etna::Auth.etna_url_param(item)] || request.env["HTTP_#{fill}#{item.upcase}"] 
+      params(request)[Etna::Auth.etna_url_param(item)] || request.env["HTTP_#{fill}#{item.upcase}"]
     end
 
     # If the application asks for a redirect for unauthorized users
@@ -77,6 +77,7 @@ module Etna
 
       begin
         payload, header = application.sign.jwt_decode(token)
+        payload['token'] = token
         return request.env['etna.user'] = Etna::User.new(payload.map{|k,v| [k.to_sym, v]}.to_h)
       rescue
         # bail out if anything goes wrong

--- a/lib/etna/test_auth.rb
+++ b/lib/etna/test_auth.rb
@@ -38,9 +38,8 @@ module Etna
 
       # here we simply base64-encode our user hash and pass it through
       payload = JSON.parse(Base64.decode64(token))
-      payload['token'] = token
 
-      request.env['etna.user'] = Etna::User.new(payload.map{|k,v| [k.to_sym, v]}.to_h)
+      request.env['etna.user'] = Etna::User.new(payload.map{|k,v| [k.to_sym, v]}.to_h, token)
     end
 
     def approve_hmac(request)

--- a/lib/etna/test_auth.rb
+++ b/lib/etna/test_auth.rb
@@ -38,6 +38,7 @@ module Etna
 
       # here we simply base64-encode our user hash and pass it through
       payload = JSON.parse(Base64.decode64(token))
+      payload['token'] = token
 
       request.env['etna.user'] = Etna::User.new(payload.map{|k,v| [k.to_sym, v]}.to_h)
     end

--- a/lib/etna/user.rb
+++ b/lib/etna/user.rb
@@ -6,8 +6,9 @@ module Etna
       'V' => :viewer
     }
 
-    def initialize params
-      @first, @last, @email, @encoded_permissions, @token = params.values_at(:first, :last, :email, :perm, :token)
+    def initialize params, token=nil
+      @first, @last, @email, @encoded_permissions = params.values_at(:first, :last, :email, :perm)
+      @token = token unless !token
       raise ArgumentError, "No email given!" unless @email
     end
 

--- a/lib/etna/user.rb
+++ b/lib/etna/user.rb
@@ -7,11 +7,11 @@ module Etna
     }
 
     def initialize params
-      @first, @last, @email, @encoded_permissions = params.values_at(:first, :last, :email, :perm)
+      @first, @last, @email, @encoded_permissions, @token = params.values_at(:first, :last, :email, :perm, :token)
       raise ArgumentError, "No email given!" unless @email
     end
 
-    attr_reader :first, :last, :email
+    attr_reader :first, :last, :email, :token
 
     def permissions
       @permissions ||= @encoded_permissions.split(/\;/).map do |roles|

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 describe Etna::Auth do
   include Rack::Test::Methods
   attr_reader :app

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 describe Etna::Auth do
   include Rack::Test::Methods
   attr_reader :app
@@ -66,8 +68,10 @@ describe Etna::Auth do
     end
 
     context 'valid tokens' do
+      authenticated_user = nil
       before(:each) do
-        Arachne::Server.get('/test') { success(@user.class) }
+        authenticated_user = nil
+        Arachne::Server.get('/test') { authenticated_user = @user; success(@user.class) }
 
         @public_key = OpenSSL::PKey::RSA.new(@private_key).public_key.to_s
 
@@ -96,6 +100,7 @@ describe Etna::Auth do
         get('/test')
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('Etna::User')
+        expect(authenticated_user.token).to eq(token)
       end
 
       it 'accepts a token via cookie' do
@@ -110,6 +115,7 @@ describe Etna::Auth do
         get('/test')
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('Etna::User')
+        expect(authenticated_user.token).to eq(token)
       end
     end
 
@@ -135,8 +141,8 @@ describe Etna::Auth do
           [ Etna::Auth ],
           test: {
             rsa_private: @private_key,
-            rsa_public: @invalid_public_key, 
-            token_algo: 'RS256' 
+            rsa_public: @invalid_public_key,
+            token_algo: 'RS256'
           },
         )
 
@@ -169,7 +175,7 @@ describe Etna::Auth do
           [ Etna::Auth ],
           test: {
             rsa_private: @private_key,
-            rsa_public: @invalid_public_key, 
+            rsa_public: @invalid_public_key,
             token_algo: 'RS256',
             auth_redirect: "https://janus.test"
 

--- a/spec/test_auth_spec.rb
+++ b/spec/test_auth_spec.rb
@@ -24,12 +24,15 @@ describe Etna::TestAuth do
       Arachne::Server,
       [ Etna::TestAuth ]
     )
-    header(*Etna::TestAuth.token_header(
+
+    token_params = {
       email: 'janus@two-faces.org',
       first: 'Janus',
       last: 'Bifrons',
       perm: 'a:labors;e:olympics,argo;v:constellations'
-    ))
+    }
+
+    header(*Etna::TestAuth.token_header(token_params))
     get('/test')
 
     expect(last_response.status).to eq(200)
@@ -37,12 +40,7 @@ describe Etna::TestAuth do
     expect(user).to be_a(Etna::User)
     expect(user.is_admin?('labors')).to be_truthy
     expect(user.can_edit?('constellations')).to be_falsy
-    expect(user.token).to eq(Base64.strict_encode64({
-      email: 'janus@two-faces.org',
-      first: 'Janus',
-      last: 'Bifrons',
-      perm: 'a:labors;e:olympics,argo;v:constellations'
-    }.to_json))
+    expect(user.token).to eq(Base64.strict_encode64(token_params.to_json))
   end
 
   it 'allows noauth routes through without a header' do

--- a/spec/test_auth_spec.rb
+++ b/spec/test_auth_spec.rb
@@ -37,6 +37,12 @@ describe Etna::TestAuth do
     expect(user).to be_a(Etna::User)
     expect(user.is_admin?('labors')).to be_truthy
     expect(user.can_edit?('constellations')).to be_falsy
+    expect(user.token).to eq(Base64.strict_encode64({
+      email: 'janus@two-faces.org',
+      first: 'Janus',
+      last: 'Bifrons',
+      perm: 'a:labors;e:olympics,argo;v:constellations'
+    }.to_json))
   end
 
   it 'allows noauth routes through without a header' do

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -1,18 +1,35 @@
 require_relative '../lib/etna/user'
 
 describe Etna::User do
-  it 'returns basic user info' do
+  it 'returns basic user info with token' do
     u = Etna::User.new(
-      email: 'janus@two-faces.org',
-      first: 'Janus',
-      last: 'Bifrons',
-      perm: 'a:labors;e:olympics,argo;v:constellations',
-      token: 'xyz123randomtoken'
+      {
+        email: 'janus@two-faces.org',
+        first: 'Janus',
+        last: 'Bifrons',
+        perm: 'a:labors;e:olympics,argo;v:constellations'
+      },
+      'xyz123randomtoken'
     )
     expect(u.first).to eq('Janus')
     expect(u.last).to eq('Bifrons')
     expect(u.email).to eq('janus@two-faces.org')
     expect(u.token).to eq('xyz123randomtoken')
+  end
+
+  it 'returns basic user info without token param' do
+    u = Etna::User.new(
+      {
+        email: 'janus@two-faces.org',
+        first: 'Janus',
+        last: 'Bifrons',
+        perm: 'a:labors;e:olympics,argo;v:constellations'
+      }
+    )
+    expect(u.first).to eq('Janus')
+    expect(u.last).to eq('Bifrons')
+    expect(u.email).to eq('janus@two-faces.org')
+    expect(u.token).to eq(nil)
   end
 
   context "permissions" do

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -6,11 +6,13 @@ describe Etna::User do
       email: 'janus@two-faces.org',
       first: 'Janus',
       last: 'Bifrons',
-      perm: 'a:labors;e:olympics,argo;v:constellations'
+      perm: 'a:labors;e:olympics,argo;v:constellations',
+      token: 'xyz123randomtoken'
     )
     expect(u.first).to eq('Janus')
     expect(u.last).to eq('Bifrons')
     expect(u.email).to eq('janus@two-faces.org')
+    expect(u.token).to eq('xyz123randomtoken')
   end
 
   context "permissions" do


### PR DESCRIPTION
#39 

Note that this is on top of your `graft-repair-hmac` branch, and not on top of master.

Adds a `token` attribute to the `User` class, and passes that data in during the Auth process (plus for TestAuth).