### PR TITLE
Use uri.request_uri to get query params into HTTP connection

### DIFF
--- a/etna.gemspec
+++ b/etna.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name              = 'etna'
-  spec.version           = '0.1.10'
+  spec.version           = '0.1.11'
   spec.summary           = 'Base classes for Mount Etna applications'
   spec.description       = 'See summary'
   spec.email             = 'Saurabh.Asthana@ucsf.edu'

--- a/lib/etna/client.rb
+++ b/lib/etna/client.rb
@@ -56,7 +56,6 @@ module Etna
       @http ||= begin
                   http = Net::HTTP::Persistent.new
                   http.read_timeout = 3600
-                  http.verify_mode = OpenSSL::SSL::VERIFY_NONE  # TAKE OUT FOR PRODUCTION
                   http
                 end
     end

--- a/lib/etna/client.rb
+++ b/lib/etna/client.rb
@@ -56,6 +56,7 @@ module Etna
       @http ||= begin
                   http = Net::HTTP::Persistent.new
                   http.read_timeout = 3600
+                  http.verify_mode = OpenSSL::SSL::VERIFY_NONE  # TAKE OUT FOR PRODUCTION
                   http
                 end
     end
@@ -93,7 +94,7 @@ module Etna
     def query_request(type, endpoint, params={}, &block)
       uri = request_uri(endpoint)
       uri.query = URI.encode_www_form(params)
-      req = type.new(uri.path, request_params)
+      req = type.new(uri.request_uri, request_params)
       request(uri, req, &block)
     end
 


### PR DESCRIPTION
Close #43 

If we want to convert everything to the standard library, then we can ignore this. Opening this because the Magma changes I'm making in mountetna/magma#139 depend on this behavior.